### PR TITLE
Arc-512 do not loat npcap at init

### DIFF
--- a/pcap/main_test_windows.go
+++ b/pcap/main_test_windows.go
@@ -1,0 +1,9 @@
+package pcap
+
+import (
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = LoadNPCAP()
+}

--- a/pcap/pcap_test.go
+++ b/pcap/pcap_test.go
@@ -313,10 +313,6 @@ func ExampleBPF() {
 }
 
 func TestLoadAndFreeNpcap(t *testing.T) {
-	loaded := IsNpcapLoaded()
-	if !loaded {
-		t.Fatal("npcap has not been loaded in init")
-	}
 	err := LoadNPCAP()
 	if err != nil {
 		t.Fatal("load should not give error")
@@ -325,7 +321,7 @@ func TestLoadAndFreeNpcap(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to free npcap")
 	}
-	loaded = IsNpcapLoaded()
+	loaded := IsNpcapLoaded()
 	if loaded {
 		t.Fatal("npcap should not be loaded after free")
 	}

--- a/pcap/pcap_windows.go
+++ b/pcap/pcap_windows.go
@@ -189,10 +189,6 @@ var (
 	pcapHopenOfflinePtr uintptr
 )
 
-func init() {
-	_ = LoadNPCAP()
-}
-
 func IsNpcapLoaded() bool {
 	return pcapLoaded
 }
@@ -209,7 +205,7 @@ func FreeNpcap() error {
 	return nil
 }
 
-func IsLoadLibraryExWithSearchFlagsSupported(kernel32 windows.Handle) bool {
+func isLoadLibraryExWithSearchFlagsSupported(kernel32 windows.Handle) bool {
 	haveSearch, _ := windows.GetProcAddress(kernel32, "AddDllDirectory")
 	return haveSearch != 0
 }
@@ -227,7 +223,7 @@ func LoadNPCAP() error {
 	defer windows.FreeLibrary(kernel32)
 
 	npcapDllPath, err := resolveNpcapDllPath(kernel32)
-	if IsLoadLibraryExWithSearchFlagsSupported(kernel32) {
+	if isLoadLibraryExWithSearchFlagsSupported(kernel32) {
 		// if AddDllDirectory is present, we can use LOAD_LIBRARY_* stuff with LoadLibraryEx to avoid wpcap.dll hijacking
 		// see: https://msdn.microsoft.com/en-us/library/ff919712%28VS.85%29.aspx
 		if err == nil {
@@ -287,7 +283,7 @@ func loadKernel32() (windows.Handle, error) {
 
 func loadMsvcrt(kernel32 windows.Handle) (err error) {
 	// this requires MS VC++ runtime
-	if IsLoadLibraryExWithSearchFlagsSupported(kernel32) {
+	if isLoadLibraryExWithSearchFlagsSupported(kernel32) {
 		msvcrtHandle, err = windows.LoadLibraryEx("msvcrt.dll", 0, LOAD_LIBRARY_SEARCH_SYSTEM32)
 	} else {
 		//load in an unsafe way. this is case is still vulnerable


### PR DESCRIPTION
If we load NPcap at init, then the dll will be in use by the process and Arc setup will be unable to uninstall NPcap